### PR TITLE
Added a new `--host` command line argument 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ You can also stream your own WAV file by running:
 
 To check out how this functionality is implemented, look at the conditional `elif method == 'wav'` in our `sender` function.
 
+<Alert type="info">
+Running an on-prem Deepgram deployment? You can provide your custom URL to the test suite with the `--host` argument.
+</Alert>
+
 ### Stream Your Microphone
 
 The streaming test suite also has the ability to send audio from your microphone to Deepgram for transcription. 

--- a/test_suite.py
+++ b/test_suite.py
@@ -302,7 +302,7 @@ def validate_dg_host(dg_host):
         return dg_host 
 
     raise argparse.ArgumentTypeError(
-            f'{dg_host} is invalid. Please provide the "{{wss|ws}}://hostname[:port]".'
+            f'{dg_host} is invalid. Please provide a WebSocket URL in the format "{{wss|ws}}://hostname[:port]".'
     )
 
 def parse_args():
@@ -334,7 +334,7 @@ def parse_args():
     #Parse the host
     parser.add_argument(
         "--host",
-        help='Point the test suite at a particular Deepgram URL. Takes "{{wss|ws}}://hostname[:port]" as its value, defaults to "wss://api.deepgram.com".',
+        help='Point the test suite at a specific Deepgram URL (useful for on-prem deployments). Takes "{{wss|ws}}://hostname[:port]" as its value. Defaults to "wss://api.deepgram.com".',
         nargs="?",
         const=1,
         default="wss://api.deepgram.com",

--- a/test_suite.py
+++ b/test_suite.py
@@ -295,10 +295,13 @@ def validate_format(format):
 
 def validate_dg_host(dg_host):
     if (
-        #Check that the host contains "wss://" or "ws://"
+        # Check that the host is a websocket URL
         dg_host.startswith("wss://")
         or dg_host.startswith("ws://")
     ):
+        # Trim trailing slash if necessary
+        if dg_host[-1] == '/':
+            return dg_host[:-1]
         return dg_host 
 
     raise argparse.ArgumentTypeError(

--- a/test_suite.py
+++ b/test_suite.py
@@ -349,10 +349,11 @@ def main():
     args = parse_args()
     input = args.input
     format = args.format.lower()
+    host = args.host
 
     try:
         if input.lower().startswith("mic"):
-            asyncio.run(run(args.key, "mic", format))
+            asyncio.run(run(args.key, "mic", format, host=host))
 
         elif input.lower().endswith("wav"):
             if os.path.exists(input):
@@ -378,7 +379,7 @@ def main():
                             sample_width=sample_width,
                             sample_rate=sample_rate,
                             filepath=args.input,
-                            host=args.host,
+                            host=host,
                         )
                     )
             else:
@@ -387,7 +388,7 @@ def main():
                 )
 
         elif input.lower().startswith("http"):
-            asyncio.run(run(args.key, "url", format, url=input))
+            asyncio.run(run(args.key, "url", format, url=input, host=host))
 
         else:
             raise argparse.ArgumentTypeError(

--- a/test_suite.py
+++ b/test_suite.py
@@ -69,7 +69,7 @@ def mic_callback(input_data, frame_count, time_info, status_flag):
 
 
 async def run(key, method, format, **kwargs):
-    deepgram_url = "wss://api.deepgram.com/v1/listen?punctuate=true"
+    deepgram_url = f'{kwargs["host"]}/v1/listen?punctuate=true'
 
     if method == "mic":
         deepgram_url += "&encoding=linear16&sample_rate=16000"
@@ -293,6 +293,17 @@ def validate_format(format):
         f'{format} is invalid. Please enter "text", "vtt", or "srt".'
     )
 
+def validate_dg_host(dg_host):
+    if (
+        #Check that the host contains "wss://" or "ws://"
+        dg_host.startswith("wss://")
+        or dg_host.startswith("ws://")
+    ):
+        return dg_host 
+
+    raise argparse.ArgumentTypeError(
+            f'{dg_host} is invalid. Please provide the "{{wss|ws}}://hostname[:port]".'
+    )
 
 def parse_args():
     """Parses the command-line arguments."""
@@ -319,6 +330,15 @@ def parse_args():
         const=1,
         default="text",
         type=validate_format,
+    )
+    #Parse the host
+    parser.add_argument(
+        "--host",
+        help='Point the test suite at a particular Deepgram URL. Takes "{{wss|ws}}://hostname[:port]" as its value, defaults to "wss://api.deepgram.com".',
+        nargs="?",
+        const=1,
+        default="wss://api.deepgram.com",
+        type=validate_dg_host,
     )
     return parser.parse_args()
 
@@ -358,6 +378,7 @@ def main():
                             sample_width=sample_width,
                             sample_rate=sample_rate,
                             filepath=args.input,
+                            host=args.host,
                         )
                     )
             else:


### PR DESCRIPTION
with support for either `wss://` or `ws://` hostnames. This will now support on-prem deployments.