### PR TITLE
Minor caption refactoring, correct `--format` flag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ First, make sure [pyaudio](https://pypi.org/project/PyAudio/) and its [portaudio
 
 In addition to printing transcripts to the terminal, the test suite can also wrap Deepgram's responses in two common subtitle formats, SRT or VTT. 
 
-To generate SRT or VTT files, add the `-o/--output` parameter when running the test suite:
+To generate SRT or VTT files, add the `-f/--format` parameter when running the test suite:
 
-`python test_suite.py -k YOUR_DEEPGRAM_API_KEY [-i mic|/path/to/audio.wav] [-o text|vtt|srt]`
+`python test_suite.py -k YOUR_DEEPGRAM_API_KEY [-i mic|/path/to/audio.wav] [-f text|vtt|srt]`
 
 This parameter defaults to `text`, which outputs responses to your terminal.
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -43,21 +43,16 @@ def subtitle_formatter(response, format):
 
     start = response["start"]
     end = start + response["duration"]
-    transcript = (
-        response.get("channel", {}).get("alternatives", [{}])[0].get("transcript", "")
+    transcript = response.get("channel", {}).get("alternatives", [{}])[0].get("transcript", "")
+
+    separator = "," if format == "srt" else '.'
+    prefix = "- " if format == "vtt" else ""
+    subtitle_string = (
+        f"{subtitle_line_counter}\n"
+        f"{subtitle_time_formatter(start, separator)} --> "
+        f"{subtitle_time_formatter(end, separator)}\n"
+        f"{prefix}{transcript}\n\n"
     )
-
-    if format == "srt":
-        separator = ","
-    else:
-        separator = "."
-
-    subtitle_string = f"{subtitle_line_counter}\n"
-    subtitle_string += f"{subtitle_time_formatter(start, separator)} --> "
-    subtitle_string += f"{subtitle_time_formatter(end, separator)}\n"
-    if format == "vtt":
-        subtitle_string += "- "
-    subtitle_string += f"{transcript}\n\n"
 
     return subtitle_string
 


### PR DESCRIPTION
- Unify caption code with the SDK version: https://github.com/deepgram/deepgram-python-sdk/pull/95
- Specify correct `-f/--format` flag in readme for caption output

Tested by running `text`, `srt`, and `vtt` with the old and new code, doing a diff for each, and ensuring there were only incidental punctuation/capitalization variations between the two.

Text:
```
We the people of the United States.
In order to form a more perfect union
...
```

SRT:
```
1
00:00:00,000 --> 00:00:02,459
We the people of the United States,


2
00:00:02,459 --> 00:00:04,389
in order to form a more perfect union
...
```

WebVTT:
```
WEBVTT

1
00:00:00.000 --> 00:00:02.459
- We the people of the United States,


2
00:00:02.459 --> 00:00:04.389
- in order to form a more perfect union,
...
```