### PR TITLE
Add args for model, tier, printing timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ You must have:
 
 A note on installing PortAudio: if you use brew or conda, we recommend installing with `brew install portaudio` or `conda install portaudio`. Otherwise, you can download a zip file from [portaudio.com](http://portaudio.com/), unzip it, and then consult [PortAudio's docs](http://www.portaudio.com/docs/v19-doxydocs/pages.html) as a reference for how to build the package on your operating system. For Linux and MacOS, the build command within the top-level `portaudio/` directory is `./configure && make`.
 
+### Additional Options
+
+The following arguments can be appended to any test suite command.
+
+`--model/-m`: Specify a Deepgram model. Example: `--model general`
+
+`--tier/-t`: Specify a Deepgram model tier. Example: `--tier nova`
+
+`--timestamps/-ts`: Opt-in to printing start and end timestamps for each streaming response. Example: `--timestamps`
+
 ## 1. Streaming a Local Source
 
 The first step in getting started with Deepgram's audio streaming capabilities is to learn how to stream a local audio source to Deepgram. This simple task allows you to learn the basic concepts of how Deepgram's API works without worrying about complexities that arise with other audio sources. Additionally, it ensures that you can receive results from Deepgram in your development environment.

--- a/README.md
+++ b/README.md
@@ -30,16 +30,6 @@ You must have:
 
 A note on installing PortAudio: if you use brew or conda, we recommend installing with `brew install portaudio` or `conda install portaudio`. Otherwise, you can download a zip file from [portaudio.com](http://portaudio.com/), unzip it, and then consult [PortAudio's docs](http://www.portaudio.com/docs/v19-doxydocs/pages.html) as a reference for how to build the package on your operating system. For Linux and MacOS, the build command within the top-level `portaudio/` directory is `./configure && make`.
 
-### Additional Options
-
-The following arguments can be appended to any test suite command.
-
-`--model/-m`: Specify a Deepgram model. Example: `--model general`
-
-`--tier/-t`: Specify a Deepgram model tier. Example: `--tier nova`
-
-`--timestamps/-ts`: Opt-in to printing start and end timestamps for each streaming response. Example: `--timestamps`
-
 ## 1. Streaming a Local Source
 
 The first step in getting started with Deepgram's audio streaming capabilities is to learn how to stream a local audio source to Deepgram. This simple task allows you to learn the basic concepts of how Deepgram's API works without worrying about complexities that arise with other audio sources. Additionally, it ensures that you can receive results from Deepgram in your development environment.
@@ -84,7 +74,27 @@ First, make sure [pyaudio](https://pypi.org/project/PyAudio/) and its [portaudio
 
 `python test_suite.py -k YOUR_DEEPGRAM_API_KEY -i mic`
 
-## Subtitle Generation
+## Additional Options
+
+The following arguments can be appended to any test suite command.
+
+### Parameters
+
+`--model/-m`: Specify a Deepgram model. Example: `--model phonecall`. Defaults to `general`.
+
+`--tier/-t`: Specify a Deepgram model tier. Example: `--tier nova`. Defaults to none specified.
+
+### Timestamps
+
+`--timestamps/-ts`: Opt-in to printing start and end timestamps in seconds for each streaming response. Example: `--timestamps`
+
+Sample output line with timestamps:
+
+```
+In order to form a more perfect union, [2.5 - 4.26]
+```
+
+### Subtitle Generation
 
 In addition to printing transcripts to the terminal, the test suite can also wrap Deepgram's responses in two common subtitle formats, SRT or VTT. 
 


### PR DESCRIPTION
Allow the user to specify __which model and/or tier__ to stream against. Prints whatever information is provided.

```
% python3 test_suite.py -k <key> -i file.wav --tier nova                
ℹ️  Request ID: <id>
ℹ️  Tier: nova
```

```
% python3 test_suite.py -k <key> -i file.wav --model general --tier nova                
ℹ️  Request ID: <id>
ℹ️  Model: general
ℹ️  Tier: nova
```

Provides an error if the model or tier is not valid. Warns users that Whisper is not supported by streaming if they enter a model containing "whisper".

-------

Allow the user to __opt-in to printing timestamps__ along with their transcript. This can be helpful for quickly grabbing timestamps or when using the file-streaming test suite functionality to compare against known timestamps to analyze timing accuracy.

```
% python3 test_suite.py -k <key> -i preamble.wav -ts 
ℹ️  Request ID: <id>
🟢 (1/5) Successfully opened Deepgram streaming connection
🟢 (2/5) Ready to stream preamble.wav audio to Deepgram
🟢 (3/5) Successfully receiving Deepgram messages, waiting for finalized transcription...
🟢 (4/5) Began receiving transcription
We the people of the United States, [0.43467742 - 2.2524192]
in order to form a more perfect union [2.5 - 4.39]
established justice, [4.91 - 5.71]
ensure domestic tranquility, [6.2779546 - 7.4711366]
provide for the common defense. [8.1085415 - 9.277292]
Promote the general welfare. [9.83079 - 10.836579]
And secure the blessings of liberty [11.080001 - 12.730001]
to ourselves and our [12.847858 - 13.97643]
do gain and establish this constitution. [14.745911 - 16.802275]
The United States of America. [17.12643 - 18.523573]
🟢 (5/5) Successfully closed Deepgram connection, waiting for final transcripts if necessary
🟢 Request finished with a duration of 19.097939 seconds. Exiting!
```