### PR TITLE
bump pyaudio to support python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp==3.7.4.post0
-PyAudio==0.2.13
+PyAudio==0.2.14
 pydub==0.25.1
 websockets==10.3


### PR DESCRIPTION
pyaudio 0.2.13 fails to install in python 3.12 environment due to a removed deprecated module

```
      AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

Upgrading to 0.2.14 resolves this. Also verified that test_suite.py works with pyaudio 0.2.14.